### PR TITLE
Use Devise.secure_compare to authorize the api key.

### DIFF
--- a/app/controllers/spree/api/spree_signifyd/orders_controller.rb
+++ b/app/controllers/spree/api/spree_signifyd/orders_controller.rb
@@ -24,23 +24,15 @@ module Spree::Api::SpreeSignifyd
       request_sha = request.headers['HTTP_HTTP_X_SIGNIFYD_HMAC_SHA256']
       computed_sha = build_sha(SpreeSignifyd::Config[:api_key], request.raw_post)
 
-      if request_sha != computed_sha
-        head 401
-      end
+      head 401 unless Devise.secure_compare(request_sha, computed_sha)
     end
 
     def load_order
-      @order = Spree::Order.find_by(number: body['orderId'])
-
-      if !@order
-        head 404
-      end
+      head 404 unless @order = Spree::Order.find_by(number: body['orderId'])
     end
 
     def order_canceled_or_shipped
-      if @order.shipped? || @order.canceled?
-        head 200
-      end
+      head 200 if @order.shipped? || @order.canceled?
     end
 
     def body

--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -4,6 +4,7 @@ require 'spree_signifyd/create_signifyd_case'
 require 'spree_signifyd/engine'
 require 'spree_signifyd/request_verifier'
 require 'resque'
+require 'devise'
 
 module SpreeSignifyd
 

--- a/spree_signifyd.gemspec
+++ b/spree_signifyd.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'resque', '~> 1.25.1'
   s.add_dependency 'signifyd', '~> 0.1.5'
   s.add_dependency 'spree_core', '2.2.2'
+  s.add_dependency 'devise'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
So that we prevent timing attacks where the attacker can gain
information about what the token is based on how quickly '==' returns
since '==' can exit before evaluating the entire string.