### PR TITLE
Ready shipments instead of updating state directly on approve

### DIFF
--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -19,7 +19,7 @@ module SpreeSignifyd
 
   def approve(order:)
     order.contents.approve(name: self.name)
-    order.shipments.each { |shipment| shipment.update!(order) }
+    order.shipments.each { |shipment| shipment.ready! }
     order.updater.update_shipment_state
     order.save!
   end


### PR DESCRIPTION
* If we dont use the state machine hooks, auto-shipping pending packages does not work.