### PR TITLE
Ready shipments instead of updating state directly on approve

### DIFF
--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -20,7 +20,7 @@ module SpreeSignifyd
 
   def approve(order:)
     order.contents.approve(name: self.name)
-    order.shipments.each { |shipment| shipment.update!(order) }
+    order.shipments.each { |shipment| shipment.ready! }
     order.updater.update_shipment_state
     order.save!
   end

--- a/spec/lib/spree_signifyd_spec.rb
+++ b/spec/lib/spree_signifyd_spec.rb
@@ -31,6 +31,11 @@ module SpreeSignifyd
 
       let(:order) { FactoryGirl.create(:order_ready_to_ship, line_items_count: 1) }
 
+      before do
+        order.shipments.each { |shipment| shipment.update_attributes!(state: 'pending') }
+        order.updater.update_shipment_state
+      end
+
       def approve
         SpreeSignifyd.approve(order: order)
       end
@@ -44,8 +49,8 @@ module SpreeSignifyd
         end
       end
 
-      it 'updates all of the shipments' do
-        order.shipments.each { |shipment| shipment.should_receive(:update!) }
+      it 'readies all of the shipments' do
+        order.shipments.each { |shipment| shipment.should_receive(:ready!) }
         approve
       end
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -4,6 +4,11 @@ describe Spree::Order, :type => :model do
 
   let!(:order) { create(:order_ready_to_ship, line_items_count: 1) }
 
+  before do
+    order.shipments.each { |shipment| shipment.update_attributes!(state: 'pending') }
+    order.updater.update_shipment_state
+  end
+
   describe "#is_risky?" do
     subject { order.is_risky? }
 


### PR DESCRIPTION
* If we dont use the state machine hooks, auto-shipping pending packages does not work.