### PR TITLE
Pass order number to background events instead of id.

### DIFF
--- a/app/models/spree_signifyd/order_decorator.rb
+++ b/app/models/spree_signifyd/order_decorator.rb
@@ -3,7 +3,7 @@ module SpreeSignifyd::OrderDecorator
 
   included do
     Spree::Order.state_machine.after_transition to: :complete, unless: :approved? do |order, transition|
-      SpreeSignifyd.create_case(order_id: order.id)
+      SpreeSignifyd.create_case(order_number: order.number)
     end
 
     has_one :signifyd_order_score, class_name: "SpreeSignifyd::OrderScore"

--- a/lib/spree_signifyd.rb
+++ b/lib/spree_signifyd.rb
@@ -25,8 +25,9 @@ module SpreeSignifyd
     order.save!
   end
 
-  def create_case(order_id:)
-    Resque.enqueue(SpreeSignifyd::CreateSignifydCase, order_id)
+  def create_case(order_number:)
+    Rails.logger.info "Queuing Signifyd case creation event: #{order_number}"
+    Resque.enqueue(SpreeSignifyd::CreateSignifydCase, order_number)
   end
 
   def score_above_threshold?(score)

--- a/lib/spree_signifyd/create_signifyd_case.rb
+++ b/lib/spree_signifyd/create_signifyd_case.rb
@@ -2,8 +2,9 @@ module SpreeSignifyd
   class CreateSignifydCase
     @queue = :spree_backend_high
 
-    def self.perform(order_id)
-      order = Spree::Order.find(order_id)
+    def self.perform(order_number_or_id)
+      Rails.logger.info "Processing Signifyd case creation event: #{order_number_or_id}"
+      order = Spree::Order.find_by(number: order_number_or_id) || Spree::Order.find(order_number_or_id)
       order_data = JSON.parse(OrderSerializer.new(order).to_json)
       Signifyd::Case.create(order_data, SpreeSignifyd::Config[:api_key])
     end

--- a/spec/lib/spree_signifyd/create_signifyd_case_spec.rb
+++ b/spec/lib/spree_signifyd/create_signifyd_case_spec.rb
@@ -10,6 +10,11 @@ module SpreeSignifyd
         Signifyd::Case.should_receive(:create).with(json, SpreeSignifyd::Config[:api_key])
         CreateSignifydCase.perform(order.id)
       end
+
+      it "calls Signifyd::Case#create with the correct params" do
+        Signifyd::Case.should_receive(:create).with(json, SpreeSignifyd::Config[:api_key])
+        CreateSignifydCase.perform(order.number)
+      end
     end
   end
 end

--- a/spec/lib/spree_signifyd_spec.rb
+++ b/spec/lib/spree_signifyd_spec.rb
@@ -58,7 +58,7 @@ module SpreeSignifyd
     describe ".create_case" do
       it 'enqueues in resque' do
         expect(Resque).to receive(:enqueue).with(SpreeSignifyd::CreateSignifydCase, 111)
-        SpreeSignifyd.create_case(order_id: 111)
+        SpreeSignifyd.create_case(order_number: 111)
       end
     end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -35,7 +35,7 @@ describe Spree::Order, :type => :model do
     let!(:payment) { create(:payment, amount: order.total, order: order ) }
 
     it "calls #create_signifyd_case" do
-      expect(SpreeSignifyd).to receive(:create_case).with(order_id: order.id)
+      expect(SpreeSignifyd).to receive(:create_case).with(order_number: order.number)
       order.complete!
     end
 

--- a/spree_signifyd.gemspec
+++ b/spree_signifyd.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_signifyd'
-  s.version     = '2.2.7'
+  s.version     = '2.2.8'
   s.summary     = 'Spree extension for communicating with Signifyd to check orders for fraud.'
   s.description = 'Spree extension for communicating with Signifyd to check orders for fraud.'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
Since it is easier to look up an order by number in admin for the case
when this event fails, rather than having to go figure out what order
number corresponds to the primary key.